### PR TITLE
proxy: better handle missing file results from OpenCOR's CORS proxy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/opencor/webapp.git"
   },
   "type": "module",
-  "version": "1.20260813.0",
+  "version": "1.20260813.1",
   "engines": {
     "bun": ">=1.2.0"
   },

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -42,7 +42,7 @@
     },
     "./style.css": "./dist/opencor.css"
   },
-  "version": "1.20260813.0",
+  "version": "1.20260813.1",
   "libopencorVersion": "1.20260803.0",
   "scripts": {
     "build": "vite build && bun scripts/generate.version.ts",

--- a/src/renderer/src/common/locCommon.ts
+++ b/src/renderer/src/common/locCommon.ts
@@ -188,7 +188,8 @@ export const file = (
             }
 
             throw new Error(
-              `Failed to fetch the file through OpenCOR's CORS proxy. The server responded with a status of ${response.status}.`, {
+              `Failed to fetch the file through OpenCOR's CORS proxy. The server responded with a status of ${response.status}.`,
+              {
                 cause: response.status
               }
             );
@@ -197,10 +198,10 @@ export const file = (
             // A network/CORS error is an instance of TypeError in fetch. So, if this is the case then we try fetching
             // the file directly otherwise we re-throw the error.
 
-            if (!(error instanceof TypeError)
-             && (!(error instanceof Error)
-              || typeof(error.cause) !== 'number'
-              || ![403, 404].includes(error.cause))) {
+            if (
+              !(error instanceof TypeError) &&
+              (!(error instanceof Error) || typeof error.cause !== 'number' || ![403, 404].includes(error.cause))
+            ) {
               throw new Error(common.formatError(error));
             }
 

--- a/src/renderer/src/common/locCommon.ts
+++ b/src/renderer/src/common/locCommon.ts
@@ -188,14 +188,19 @@ export const file = (
             }
 
             throw new Error(
-              `Failed to fetch the file through OpenCOR's CORS proxy. The server responded with a status of ${response.status}.`
+              `Failed to fetch the file through OpenCOR's CORS proxy. The server responded with a status of ${response.status}.`, {
+                cause: response.status
+              }
             );
           })
           .catch((error: unknown) => {
             // A network/CORS error is an instance of TypeError in fetch. So, if this is the case then we try fetching
             // the file directly otherwise we re-throw the error.
 
-            if (!(error instanceof TypeError)) {
+            if (!(error instanceof TypeError)
+             && (!(error instanceof Error)
+              || typeof(error.cause) !== 'number'
+              || ![403, 404].includes(error.cause))) {
               throw new Error(common.formatError(error));
             }
 

--- a/src/renderer/src/common/locCommon.ts
+++ b/src/renderer/src/common/locCommon.ts
@@ -187,6 +187,8 @@ export const file = (
               return response.arrayBuffer();
             }
 
+            // If the fetch through OpenCOR's CORS proxy failed, then throw an error to trigger the catch block below.
+
             throw new Error(
               `Failed to fetch the file through OpenCOR's CORS proxy. The server responded with a status of ${response.status}.`,
               {
@@ -195,8 +197,8 @@ export const file = (
             );
           })
           .catch((error: unknown) => {
-            // A network/CORS error is an instance of TypeError in fetch. So, if this is the case then we try fetching
-            // the file directly otherwise we re-throw the error.
+            // If the fetch through OpenCOR's CORS proxy failed, then try fetching the URL directly, unless the error
+            // was a TypeError or an HTTP 403 or 404 error.
 
             if (
               !(error instanceof TypeError) &&


### PR DESCRIPTION
This was a simple and quick way at the time to handle the `Error` thrown (at line 190) when the proxy server returned a 403 (or 404) status. Given though that the files all had `http://localhost` URLs, it would have been better to not hit the proxy for them and instead rearrange the code.